### PR TITLE
Add ability to exclude words from profanity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This is where Profanify comes in, the package makes it really easy to test your 
 you may have forgotten about or had no idea they were in there in the first place. If you have your tests running as
 part of a CI/CD pipeline, then it should mean the pipeline will fail if there's any profanity in your codebase.
 
+## Installation
+
+To install Profanify, you can run the following command in your project's root:
+
+```text
+composer require jonpurvis/profanify --dev
+```
+
 ## Examples
 
 Let's take a look at how Profanify works. There's not much to it but because it's a PestPHP plugin, we can use the
@@ -57,7 +65,7 @@ following test:
 
 ```php
 expect('App')
-    ->toNotUseProfanity()
+    ->toHaveNoProfanity()
 ```
 
 The test suite would fail, because there's multiple usages of Profanity in one of the files. You don't have to only
@@ -65,13 +73,13 @@ test the whole application though, you could limit it to, for example, Controlle
 
 ```php
 expect('App\Http\Controllers')
-    ->toNotUseProfanity()
+    ->toHaveNoProfanity()
 ```
 
 You could even expect profanity, if you really wanted to:
 ```php
 expect('App\Providers')
-    ->not->toNotUseProfanity()
+    ->not->toHaveNoProfanity()
 ```
 
 If a test does fail because of Profanity, then the output will show the offending file and line. IDE's such as PHPStorm,

--- a/README.md
+++ b/README.md
@@ -22,15 +22,7 @@ works on your application. It also means your codebase is kept professional and 
 
 This is where Profanify comes in, the package makes it really easy to test your application for common swear words, that
 you may have forgotten about or had no idea they were in there in the first place. If you have your tests running as
-part of a CI/CD pipeline, then it should mean the pipeline will fail if there's any profanity in your codebase. 
-
-## Installation
-
-To install Profanify, you can run the following command in your project's root:
-
-```text
-composer require jonpurvis/profanify --dev
-```
+part of a CI/CD pipeline, then it should mean the pipeline will fail if there's any profanity in your codebase.
 
 ## Examples
 
@@ -65,7 +57,7 @@ following test:
 
 ```php
 expect('App')
-    ->toHaveNoProfanity()
+    ->toNotUseProfanity()
 ```
 
 The test suite would fail, because there's multiple usages of Profanity in one of the files. You don't have to only
@@ -73,13 +65,13 @@ test the whole application though, you could limit it to, for example, Controlle
 
 ```php
 expect('App\Http\Controllers')
-    ->toHaveNoProfanity()
+    ->toNotUseProfanity()
 ```
 
 You could even expect profanity, if you really wanted to:
 ```php
 expect('App\Providers')
-    ->not->toHaveNoProfanity()
+    ->not->toNotUseProfanity()
 ```
 
 If a test does fail because of Profanity, then the output will show the offending file and line. IDE's such as PHPStorm,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ expect('App\Providers')
     ->not->toHaveNoProfanity()
 ```
 
+There may also be times when you want to ignore certain phrases included in the profanity list. To do this, you can pass an `excluding` argument to the `toHaveNoProfanity` method. This argument should be an array of strings that you want to ignore. For example:
+
+```php
+expect('App')
+    ->toHaveNoProfanity(excluding: ['69']);
+```
+
+In the test above, the test would pass even if the word `69` was included in one of the tested files.
+
 If a test does fail because of Profanity, then the output will show the offending file and line. IDE's such as PHPStorm,
 will allow you to click the file and be taken straight to the line that contains profanity:
 

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -18,7 +18,7 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectatio
 
         $foundWords = array_filter($words, fn ($word): bool => preg_match('/\b'.preg_quote($word, '/').'\b/i', $fileContents) === 1);
 
-        return (array) $foundWords === [];
+        return $foundWords === [];
     },
     'to not use profanity',
     FileLineFinder::where(function (string $line) use (&$foundWords): bool {

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -7,10 +7,12 @@ use Pest\Arch\Expectations\Targeted;
 use Pest\Arch\Support\FileLineFinder;
 use PHPUnit\Architecture\Elements\ObjectDescription;
 
-expect()->extend('toHaveNoProfanity', fn (): ArchExpectation => Targeted::make(
+expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectation => Targeted::make(
     $this,
-    function (ObjectDescription $object) use (&$foundWords): bool {
+    function (ObjectDescription $object) use (&$foundWords, $excluding): bool {
         $words = include __DIR__.'/../Config/words.php';
+
+        $words = array_diff($words, $excluding);
 
         $fileContents = (string) file_get_contents($object->path);
 

--- a/tests/toHaveNoProfanity.php
+++ b/tests/toHaveNoProfanity.php
@@ -6,3 +6,8 @@ it('passes if a file contains no profanity', function () {
     expect('Tests\Fixtures\HasNoProfanity')
         ->toHaveNoProfanity();
 });
+
+it('passes if a file contains profanity but it is excluded', function () {
+    expect('Tests\Fixtures\HasProfanityInComment')
+        ->toHaveNoProfanity(excluding: ['shit']);
+});


### PR DESCRIPTION
Hey @JonPurvis! This PR adds the ability to pass an array of words/phrases to exclude from the profanity check.

The idea behind this is that you might sometimes have profanity-like words in your code but that is intentional. As a really basic example purely to highlight the change, something like:

```php
class Product
{
    public const BASE_PRICE = 10.69
}
```

The following test would fail because of `69`:

```php
expect('App')->toHaveNoProfanity();
```

But this test would pass:
```php
expect('App')->toHaveNoProfanity(excluding: ['69']);
```

From my quick manual testing, this looks like it works as expected. But I apologise if I've missed anything!

If this is something you think might be useful, please give me a shout if you'd like any changes made to the PR. I'll be happy to submit a PR to update the docs too 😄