### PR TITLE
Fix line detection

### DIFF
--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -22,6 +22,6 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectatio
     },
     'to not use profanity',
     FileLineFinder::where(function (string $line) use (&$foundWords): bool {
-        return str_contains($line, (string) array_values($foundWords ?? [])[0]);
+        return str_contains(strtolower($line), (string) strtolower(array_values($foundWords ?? [])[0]));
     })
 ));

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -22,6 +22,6 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectatio
     },
     'to not use profanity',
     FileLineFinder::where(function (string $line) use (&$foundWords): bool {
-        return str_contains(strtolower($line), (string) strtolower(array_values($foundWords ?? [])[0]));
+        return str_contains(strtolower($line), strtolower(array_values($foundWords ?? [])[0]));
     })
 ));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0409723d-0a4e-43ae-8b00-cb8de140284f)

`SHIT` fails the test right! But it does not detect its line (11), because it's not written in the same case as in the words list (`shit`).

![image](https://github.com/user-attachments/assets/17ae9bbe-bb94-4506-915d-5a3706c95731)

After this PR the line of `SHIT` is detected (11)

![image](https://github.com/user-attachments/assets/ac350f94-e951-43a5-aeef-f340f0e82349)
