### PR TITLE
Fix profanity not detected when included inside a word

### DIFF
--- a/src/Config/tolerated.php
+++ b/src/Config/tolerated.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'class',
+];

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -11,12 +11,17 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectatio
     $this,
     function (ObjectDescription $object) use (&$foundWords, $excluding): bool {
         $words = include __DIR__.'/../Config/words.php';
+        $toleratedWords = include __DIR__.'/../Config/tolerated.php';
 
         $words = array_diff($words, $excluding);
 
         $fileContents = (string) file_get_contents($object->path);
 
-        $foundWords = array_filter($words, fn ($word): bool => preg_match('/\b'.preg_quote($word, '/').'\b/i', $fileContents) === 1);
+        foreach ($toleratedWords as $toleratedWord) {
+            $fileContents = str_replace($toleratedWord, '', $fileContents);
+        }
+
+        $foundWords = array_filter($words, fn ($word): bool => preg_match('/'.preg_quote($word, '/').'/i', $fileContents) === 1);
 
         return $foundWords === [];
     },

--- a/tests/Fixtures/HasProfanityInShitClass.php
+++ b/tests/Fixtures/HasProfanityInShitClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class HasProfanityInShitClass
+{
+    public function __construct(
+        //
+    ) {}
+}

--- a/tests/toHaveProfanity.php
+++ b/tests/toHaveProfanity.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 use Pest\Arch\Exceptions\ArchExpectationFailedException;
 
+it('fails if a file contains profanity in class name', function () {
+    expect('Tests\Fixtures\HasProfanityInShitClass')
+        ->toHaveNoProfanity();
+})->throws(ArchExpectationFailedException::class);
+
 it('fails if a file contains profanity in a comment', function () {
     expect('Tests\Fixtures\HasProfanityInComment')
         ->toHaveNoProfanity();


### PR DESCRIPTION
Hellooo 👋🏻 

I have noticed that any profanity that's not a word on its own is not detected. Let's take for example a profanity that's on a class name or method name ... , `TheFuckController` this is not detected as profanity.

So this PR fixes this and make it possible to detect any profanity included inside a "word"

![image](https://github.com/user-attachments/assets/08fb1d1f-b723-4108-bf26-f2e2263a8f98)

![image](https://github.com/user-attachments/assets/cd7efdab-328a-42cb-9d7b-49d1037cb924)

PS: I have added a list for tolerated words so we can tolerate the words that's not profanity, like `class` it has `ass` that's profanity but the whole word should not be detected as one.