### PR TITLE
Add means for covering more profanity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ expect('App')
 
 In the test above, the test would pass even if the word `69` was included in one of the tested files.
 
+Or, you may want to test for profanity not included in the list. To do this, pass an `including` argument to the `toHaveNoProfanity` method. This argument should be an array of strings you also want to consider as profanity. For example:
+
+```php
+expect('App')
+    ->toHaveNoProfanity(including: ['dagnabbit']);
+```
+
+
 If a test does fail because of Profanity, then the output will show the offending file and line. IDE's such as PHPStorm,
 will allow you to click the file and be taken straight to the line that contains profanity:
 

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -7,10 +7,12 @@ use Pest\Arch\Expectations\Targeted;
 use Pest\Arch\Support\FileLineFinder;
 use PHPUnit\Architecture\Elements\ObjectDescription;
 
-expect()->extend('toHaveNoProfanity', fn (array $excluding = []): ArchExpectation => Targeted::make(
+expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = []): ArchExpectation => Targeted::make(
     $this,
-    function (ObjectDescription $object) use (&$foundWords, $excluding): bool {
+    function (ObjectDescription $object) use (&$foundWords, $excluding, $including): bool {
         $words = include __DIR__.'/../Config/words.php';
+
+        $words = array_merge($words, $including);
 
         $words = array_diff($words, $excluding);
 

--- a/tests/Fixtures/HasUncoveredProfanity.php
+++ b/tests/Fixtures/HasUncoveredProfanity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class HasUncoveredProfanity
+{
+    /**
+     * oh dagnabbit
+     */
+    public function __construct(
+        //
+    ) {}
+}

--- a/tests/toHaveProfanity.php
+++ b/tests/toHaveProfanity.php
@@ -18,3 +18,8 @@ it('fails if a file contains profanity in a property', function () {
     expect('Tests\Fixtures\HasProfanityInProperty')
         ->toHaveNoProfanity();
 })->throws(ArchExpectationFailedException::class);
+
+it('fails if file contains profanity manually included', function () {
+    expect('Tests\Fixtures\HasUncoveredProfanity')
+        ->toHaveNoProfanity(including: ['dagnabbit']);
+})->throws(ArchExpectationFailedException::class);


### PR DESCRIPTION
Adds an argument for specifying other words you might consider to be profane. I tried to follow the convention already set in place by the `excluding` method. 

Thanks!