### PR TITLE
add subject to tolerated words

### DIFF
--- a/src/Config/tolerated.php
+++ b/src/Config/tolerated.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 return [
     'class',
-    'subject'
+    'subject',
 ];


### PR DESCRIPTION
Following on from the awesome work that @faissaloux did in #4, I'm adding _subject_ as a tolerated word. My test suite started failing in one of my Laravel applications:

```php
return new Envelope(
    subject: 'Testing',
);
```

The word _subject_ contains **bj** 😆 

