### PR TITLE
add more tolerated words and fix account for capitalisation 

### DIFF
--- a/src/Config/tolerated.php
+++ b/src/Config/tolerated.php
@@ -5,4 +5,10 @@ declare(strict_types=1);
 return [
     'class',
     'subject',
+    'assume',
+    'start',
+    'object',
+    'parse',
+    'assign',
+    'pass',
 ];

--- a/src/Config/words.php
+++ b/src/Config/words.php
@@ -1337,7 +1337,6 @@ return [
     'shat',
     'she-male',
     'sheeeet',
-    'sheet',
     'sheister',
     'shemal3',
     'shemale',

--- a/src/Config/words.php
+++ b/src/Config/words.php
@@ -1337,6 +1337,7 @@ return [
     'shat',
     'she-male',
     'sheeeet',
+    'sheet',
     'sheister',
     'shemal3',
     'shemale',

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -20,7 +20,7 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
         $fileContents = (string) file_get_contents($object->path);
 
         foreach ($toleratedWords as $toleratedWord) {
-            $fileContents = str_replace($toleratedWord, '', $fileContents);
+            $fileContents = str_replace([$toleratedWord, ucwords($toleratedWord)], '', $fileContents);
         }
 
         $foundWords = array_filter($words, fn ($word): bool => preg_match('/'.preg_quote($word, '/').'/i', $fileContents) === 1);

--- a/tests/Fixtures/HasCapitalisedToleratedProfanity.php
+++ b/tests/Fixtures/HasCapitalisedToleratedProfanity.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class HasCapitalisedToleratedProfanity
+{
+    // We should Start by adding a construct
+}

--- a/tests/toHaveNoProfanity.php
+++ b/tests/toHaveNoProfanity.php
@@ -11,3 +11,8 @@ it('passes if a file contains profanity but it is excluded', function () {
     expect('Tests\Fixtures\HasProfanityInComment')
         ->toHaveNoProfanity(excluding: ['shit']);
 });
+
+it('passes if a file contains capitalised tolerated profanity', function () {
+    expect('Tests\Fixtures\HasCapitalisedToleratedProfanity')
+        ->toHaveNoProfanity();
+});


### PR DESCRIPTION
This PR adds a few more tolerated words based on the testing in one of my applications:

| Word | Profanity |
|--------|--------|
| assume | ass |
| start | tart |
| object | bj |
|parse| arse |
|assign| ass |
|pass|ass|

I also discovered that if you use the capitalised version of a tolerated word, it still gets flagged, so this PR fixes that. E.g. usages of `stdClass`. When we're looping through the tolerated words, we now also check the capitalised version.

@faissaloux Just so you're aware of this change 😄 