### PR TITLE
Fix tolerated words not detected

### DIFF
--- a/src/Config/tolerated.php
+++ b/src/Config/tolerated.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+// SHOULD ALL WORDS BE lowercase!
+
 return [
     'class',
     'subject',

--- a/src/Config/words.php
+++ b/src/Config/words.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+// SHOULD ALL WORDS BE lowercase!
+
 return [
     '69',
     '@55',

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -20,7 +20,7 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
         $fileContents = (string) file_get_contents($object->path);
 
         foreach ($toleratedWords as $toleratedWord) {
-            $fileContents = str_replace([$toleratedWord, ucwords($toleratedWord)], '', $fileContents);
+            $fileContents = str_replace($toleratedWord, '', strtolower($fileContents));
         }
 
         $foundWords = array_filter($words, fn ($word): bool => preg_match('/'.preg_quote($word, '/').'/i', $fileContents) === 1);

--- a/tests/Fixtures/HasCapitalisedToleratedProfanity.php
+++ b/tests/Fixtures/HasCapitalisedToleratedProfanity.php
@@ -6,5 +6,5 @@ namespace Tests\Fixtures;
 
 class HasCapitalisedToleratedProfanity
 {
-    // We should Start by adding a construct
+    // We should Start or StArT by adding a construct
 }


### PR DESCRIPTION
Hellooo 👋🏻 

@JonPurvis on https://github.com/JonPurvis/profanify/pull/9 tried to detect tolerated words which are capitalized but what if it's random like `StArT`  or all capital `START`.

So in this PR I made it more general to detect words at any case.