### PR TITLE
remove a word in pt_BR

### DIFF
--- a/src/Config/profanities/pt_BR.php
+++ b/src/Config/profanities/pt_BR.php
@@ -50,7 +50,6 @@ return [
     'cretino',
     'trouxa',
     'burro',
-    'animal',
     'viado de merda',
     'escória',
     'nojentinho',


### PR DESCRIPTION
The word "animal" is not considered profane; it is a neutral term used to describe living organisms that belong to the kingdom Animalia.