### PR TITLE
specify language

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ expect('App')
     ->toHaveNoProfanity(including: ['dagnabbit']);
 ```
 
-
 If a test does fail because of Profanity, then the output will show the offending file and line. IDE's such as PHPStorm,
 will allow you to click the file and be taken straight to the line that contains profanity:
 
@@ -109,6 +108,17 @@ at tests/Fixtures/HasProfanityInComment.php:10
   Tests:    1 failed (1 assertions)
   Duration: 0.06s
 ```
+
+By default, Profanify will scan all language files, which may cause some problems if a word in your language is fine but
+is listed as profane in another language (whether it be the whole word or . To combat this, you can specify a default language, which means only that file will be 
+checked against when the test runs:
+
+```php
+expect('App')
+    ->toHaveNoProfanity(language: 'en');
+```
+
+The example above means that only profanity in `Config/profanities/en.php` file will be picked up. 
 
 ## Languages
 Profanify currently supports the following languages:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ at tests/Fixtures/HasProfanityInComment.php:10
 ```
 
 By default, Profanify will scan all language files, which may cause some problems if a word in your language is fine but
-is listed as profane in another language (whether it be the whole word or . To combat this, you can specify a default language, which means only that file will be 
+is listed as profane in another language. To combat this, you can specify a default language, which means only that file will be 
 checked against when the test runs:
 
 ```php

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -7,9 +7,9 @@ use Pest\Arch\Expectations\Targeted;
 use Pest\Arch\Support\FileLineFinder;
 use PHPUnit\Architecture\Elements\ObjectDescription;
 
-expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = []): ArchExpectation => Targeted::make(
+expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = [], $language = null): ArchExpectation => Targeted::make(
     $this,
-    function (ObjectDescription $object) use (&$foundWords, $excluding, $including): bool {
+    function (ObjectDescription $object) use (&$foundWords, $excluding, $including, $language): bool {
 
         $words = [];
         $profanitiesDir = __DIR__.'/../Config/profanities';
@@ -19,11 +19,19 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
         }
 
         $profanitiesFiles = array_diff($profanitiesFiles, ['.', '..']);
-        foreach ($profanitiesFiles as $profanitiesFile) {
-            $words = array_merge(
-                $words,
-                include "$profanitiesDir/$profanitiesFile"
-            );
+
+        if ($language) {
+            $specificLanguage = "$profanitiesDir/$language.php";
+            if (file_exists($specificLanguage)) {
+                $words = include $specificLanguage;
+            }
+        } else {
+            foreach ($profanitiesFiles as $profanitiesFile) {
+                $words = array_merge(
+                    $words,
+                    include "$profanitiesDir/$profanitiesFile"
+                );
+            }
         }
 
         $toleratedWords = include __DIR__.'/../Config/tolerated.php';

--- a/tests/Fixtures/HasDifferentLanguageProfanity.php
+++ b/tests/Fixtures/HasDifferentLanguageProfanity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class HasDifferentLanguageProfanity
+{
+    /**
+     * just a merda comment
+     */
+    public function __construct(
+        //
+    ) {}
+}

--- a/tests/toHaveNoProfanity.php
+++ b/tests/toHaveNoProfanity.php
@@ -16,3 +16,8 @@ it('passes if a file contains capitalised tolerated profanity', function () {
     expect('Tests\Fixtures\HasCapitalisedToleratedProfanity')
         ->toHaveNoProfanity();
 });
+
+it('passes if a language is specified and a file contains profanity in another language', function () {
+    expect('Tests\Fixtures\HasDifferentLanguageProfanity')
+        ->toHaveNoProfanity(language: 'en');
+});

--- a/tests/toHaveProfanity.php
+++ b/tests/toHaveProfanity.php
@@ -28,3 +28,8 @@ it('fails if file contains profanity manually included', function () {
     expect('Tests\Fixtures\HasUncoveredProfanity')
         ->toHaveNoProfanity(including: ['dagnabbit']);
 })->throws(ArchExpectationFailedException::class);
+
+it('fails if file contains profanity when a specific language has been set', function () {
+    expect('Tests\Fixtures\HasProfanityInComment')
+        ->toHaveNoProfanity(language: 'en');
+})->throws(ArchExpectationFailedException::class);


### PR DESCRIPTION
This PR adds the ability to be able to specify a language. By default, the check will loop over any files with the `profanities` directory, but personally, I really only care about words in the en.php file. I've had a couple of instances where words within words are picked up within other language files. By specifying `en` as the language, I can be sure that my codebase is only getting scanned against the correct file.

My use case is one of my applications references "Customer". The word "Customer" contains "Cu" which is listed as profane in the pt_BR.php file because in Portuguese, it means "ass". 