### PR TITLE
Add found words to output

### DIFF
--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
+use JonPurvis\Profanify\Expectations\TargetedProfanity;
 use Pest\Arch\Contracts\ArchExpectation;
-use Pest\Arch\Expectations\Targeted;
 use Pest\Arch\Support\FileLineFinder;
 use PHPUnit\Architecture\Elements\ObjectDescription;
 
-expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = [], $language = null): ArchExpectation => Targeted::make(
+expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = [], $language = null): ArchExpectation => TargetedProfanity::make(
     $this,
     function (ObjectDescription $object) use (&$foundWords, $excluding, $including, $language): bool {
 
@@ -50,7 +50,9 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
 
         return $foundWords === [];
     },
-    'to not use profanity',
+    function ($path) use (&$foundWords): string {
+        return "to have no profanity, but found '".implode(', ', array_values($foundWords ?? []))."'";
+    },
     FileLineFinder::where(function (string $line) use (&$foundWords): bool {
         return str_contains(strtolower($line), strtolower((string) array_values($foundWords ?? [])[0]));
     })

--- a/src/Expectations/TargetedProfanity.php
+++ b/src/Expectations/TargetedProfanity.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JonPurvis\Profanify\Expectations;
+
+use Pest\Arch\Blueprint;
+use Pest\Arch\Collections\Dependencies;
+use Pest\Arch\Exceptions\ArchExpectationFailedException;
+use Pest\Arch\Options\LayerOptions;
+use Pest\Arch\SingleArchExpectation;
+use Pest\Arch\ValueObjects\Targets;
+use Pest\Arch\ValueObjects\Violation;
+use Pest\Expectation;
+
+/**
+ * @internal
+ */
+final class TargetedProfanity
+{
+    /**
+     * Creates an "TargetedProfanity" expectation.
+     */
+    public static function make(
+        Expectation $expectation,
+        callable $callback,
+        callable $what,
+        callable $line,
+    ): SingleArchExpectation {
+        assert(is_string($expectation->value) || is_array($expectation->value));
+        /** @var Expectation<array<int, string>|string> $expectation */
+        $blueprint = Blueprint::make(
+            Targets::fromExpectation($expectation),
+            Dependencies::fromExpectationInput([]),
+        );
+
+        return SingleArchExpectation::fromExpectation(
+            $expectation,
+            static function (LayerOptions $options) use ($callback, $blueprint, $what, $line): void {
+                $blueprint->targeted(
+                    $callback,
+                    $options,
+                    static fn (Violation $violation) => throw new ArchExpectationFailedException(
+                        $violation,
+                        sprintf(
+                            "Expecting '%s' %s.",
+                            $violation->path,
+                            $what($violation->path),
+                        ),
+                    ),
+                    $line,
+                );
+            },
+        );
+    }
+}


### PR DESCRIPTION
Closes #25

Output found words to the terminal message so it reads:
`"Expected File.php to not have profanity, but found: 'x, y, z'"`