### PR TITLE
Allow to target multiple languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,14 @@ expect('App')
     ->toHaveNoProfanity(language: 'en');
 ```
 
-The example above means that only profanity in `Config/profanities/en.php` file will be picked up. 
+The example above means that only profanity in `Config/profanities/en.php` file will be picked up.
+
+```php
+expect('App')
+    ->toHaveNoProfanity(language: ['en', 'ar']);
+```
+
+This will check for profanities in both languages `en` and `ar`.
 
 ## Languages
 Profanify currently supports the following languages:

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -10,7 +10,6 @@ use PHPUnit\Architecture\Elements\ObjectDescription;
 expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $including = [], $language = null): ArchExpectation => TargetedProfanity::make(
     $this,
     function (ObjectDescription $object) use (&$foundWords, $excluding, $including, $language): bool {
-
         $words = [];
         $profanitiesDir = __DIR__.'/../Config/profanities';
 
@@ -21,9 +20,16 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
         $profanitiesFiles = array_diff($profanitiesFiles, ['.', '..']);
 
         if ($language) {
-            $specificLanguage = "$profanitiesDir/$language.php";
-            if (file_exists($specificLanguage)) {
-                $words = include $specificLanguage;
+            $languages = is_string($language) ? [$language] : $language;
+
+            foreach ($languages as $language) {
+                $specificLanguage = "$profanitiesDir/$language.php";
+                if (file_exists($specificLanguage)) {
+                    $words = array_merge(
+                        $words,
+                        include $specificLanguage
+                    );
+                }
             }
         } else {
             foreach ($profanitiesFiles as $profanitiesFile) {

--- a/src/Expectations/Profanity.php
+++ b/src/Expectations/Profanity.php
@@ -22,8 +22,8 @@ expect()->extend('toHaveNoProfanity', fn (array $excluding = [], array $includin
         if ($language) {
             $languages = is_string($language) ? [$language] : $language;
 
-            foreach ($languages as $language) {
-                $specificLanguage = "$profanitiesDir/$language.php";
+            foreach ($languages as $lang) {
+                $specificLanguage = "$profanitiesDir/$lang.php";
                 if (file_exists($specificLanguage)) {
                     $words = array_merge(
                         $words,

--- a/tests/toHaveNoProfanity.php
+++ b/tests/toHaveNoProfanity.php
@@ -21,3 +21,8 @@ it('passes if a language is specified and a file contains profanity in another l
     expect('Tests\Fixtures\HasDifferentLanguageProfanity')
         ->toHaveNoProfanity(language: 'en');
 });
+
+it('passes if file does not contain profanity from any specified languages', function () {
+    expect('Tests\Fixtures\HasDifferentLanguageProfanity')
+        ->toHaveNoProfanity(language: ['en', 'ar']);
+});

--- a/tests/toHaveProfanity.php
+++ b/tests/toHaveProfanity.php
@@ -33,3 +33,8 @@ it('fails if file contains profanity when a specific language has been set', fun
     expect('Tests\Fixtures\HasProfanityInComment')
         ->toHaveNoProfanity(language: 'en');
 })->throws(ArchExpectationFailedException::class);
+
+it('fails if file contains profanity of multiple specified language', function () {
+    expect('Tests\Fixtures\HasProfanityInComment')
+        ->toHaveNoProfanity(language: ['en', 'ar']);
+})->throws(ArchExpectationFailedException::class);


### PR DESCRIPTION
In this PR I allow to specify multiple languages to check.

```php
expect('file')->toHaveNoProfanity(language: ['en', 'ar']);
```

This will check for english and arabic profanities.