### PR TITLE
add `assert` to tolerated list

### DIFF
--- a/src/Config/tolerated.php
+++ b/src/Config/tolerated.php
@@ -18,4 +18,5 @@ return [
     'assignable',
     'charset',
     'transliterate',
+    'assert',
 ];

--- a/tests/Fixtures/HasWordStartingWithToleratedProfanity.php
+++ b/tests/Fixtures/HasWordStartingWithToleratedProfanity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class HasWordStartingWithToleratedProfanity
+{
+    // Make an assertion
+    public function assertThis(): void
+    {
+        //
+    }
+}

--- a/tests/toHaveNoProfanity.php
+++ b/tests/toHaveNoProfanity.php
@@ -17,6 +17,11 @@ it('passes if a file contains capitalised tolerated profanity', function () {
         ->toHaveNoProfanity();
 });
 
+it('passes if a file contains word starting with tolerated profanity', function () {
+    expect('Tests\Fixtures\HasWordStartingWithToleratedProfanity')
+        ->toHaveNoProfanity();
+});
+
 it('passes if a language is specified and a file contains profanity in another language', function () {
     expect('Tests\Fixtures\HasDifferentLanguageProfanity')
         ->toHaveNoProfanity(language: 'en');


### PR DESCRIPTION
I think `assert` can be a common word in codebase 

I've also added a new test that I thought would be useful here 