### PR TITLE
#45 Remove 2 words from NL profanities list

### DIFF
--- a/src/Config/profanities/nl.php
+++ b/src/Config/profanities/nl.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 return [
     // General insults
-    'eikel',
     'hufter',
     'idioot',
     'mongool',
@@ -16,7 +15,6 @@ return [
     'lulletje',
     'trut',
     'zeikerd',
-    'pannenkoek',
 
     // Stronger insults
     'teringlijer',


### PR DESCRIPTION
These are prone to be false positives.

Fixes #45 