### PR TITLE
Refactor `ProfanityAnalyser`

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -18,17 +18,17 @@ final class Analyser
      * @param  \Closure(\Pest\Profanity\Result): void  $callback
      * @param  array<string>  $excludingWords
      * @param  array<string>  $includingWords
-     * @param  string|array<string>|null  $language
+     * @param  array<string>|null  $languages
      */
     public static function analyse(
         array $files,
         Closure $callback,
         array $excludingWords = [],
         array $includingWords = [],
-        $language = null
+        $languages = null
     ): void {
         foreach ($files as $file) {
-            $errors = ProfanityAnalyser::analyse($file, $excludingWords, $includingWords, $language);
+            $errors = ProfanityAnalyser::analyse($file, $excludingWords, $includingWords, $languages);
             $callback(new Result($file, $errors));
         }
     }

--- a/src/ProfanityAnalyser.php
+++ b/src/ProfanityAnalyser.php
@@ -14,10 +14,10 @@ final class ProfanityAnalyser
      *
      * @param  array<string>  $excludingWords
      * @param  array<string>  $includingWords
-     * @param  string|array<string>|null  $language
+     * @param  array<string>|null  $languages
      * @return array<int, Error>
      */
-    public static function analyse(string $file, array $excludingWords = [], array $includingWords = [], $language = null): array
+    public static function analyse(string $file, array $excludingWords = [], array $includingWords = [], $languages = null): array
     {
         $words = [];
         $profanitiesDir = __DIR__.'/Config/profanities';
@@ -33,9 +33,7 @@ final class ProfanityAnalyser
 
         $profanitiesFiles = array_diff($profanitiesFiles, ['.', '..']);
 
-        if ($language) {
-            $languages = is_array($language) ? $language : [$language];
-
+        if ($languages) {
             foreach ($languages as $lang) {
                 $specificLanguage = "$profanitiesDir/$lang.php";
                 if (file_exists($specificLanguage)) {
@@ -46,12 +44,7 @@ final class ProfanityAnalyser
                 }
             }
         } else {
-            foreach ($profanitiesFiles as $profanitiesFile) {
-                $words = array_merge(
-                    $words,
-                    include "$profanitiesDir/en.php"
-                );
-            }
+            $words = include "$profanitiesDir/en.php";
         }
 
         $words = array_merge($words, $includingWords);


### PR DESCRIPTION
After making `en` the default language in https://github.com/pestphp/pest-plugin-profanity/commit/36a3df5d18977807d735997ea31bfd9baddd3f07, I refactored the `ProfanityAnalyser` accordingly.

### Changes
- `$language` can't be string anymore (always array), I changed it's type and also name to `$languages`.
- We don't need that line to check if `$languages` is array anymore.
- We don't need that for loop anymore, it's one file (`en.php`).