### PR TITLE
fix: Implemented whole word matching in ProfanityAnalyser class

### DIFF
--- a/src/ProfanityAnalyser.php
+++ b/src/ProfanityAnalyser.php
@@ -58,9 +58,9 @@ final class ProfanityAnalyser
         foreach ($words as $word) {
             foreach ($lines as $lineNumber => $line) {
                 $key = $lineNumber.'-'.$word;
-                if (preg_match('/(?<!\p{L})'.preg_quote($word, '/').'(?!\p{L})/iu', $line) === 1 && !isset($foundProfanity[$key])) {
+                if (preg_match('/(?<!\p{L})'.preg_quote($word, '/').'(?!\p{L})/iu', $line) === 1 && ! isset($foundProfanity[$key])) {
                     // Skip reporting profanity if the line contains the ignore annotation
-                    if (!str_contains($line, '@pest-ignore-profanity')) {
+                    if (! str_contains($line, '@pest-ignore-profanity')) {
                         $errors[] = new Error($file, $lineNumber + 1, $word);
                         $foundProfanity[$key] = true;
                     }

--- a/src/ProfanityAnalyser.php
+++ b/src/ProfanityAnalyser.php
@@ -56,15 +56,13 @@ final class ProfanityAnalyser
         $foundProfanity = [];
 
         foreach ($words as $word) {
-            if (preg_match('/\b'.preg_quote($word, '/').'\b/i', $fileContents) === 1) {
-                foreach ($lines as $lineNumber => $line) {
-                    $key = $lineNumber.'-'.$word;
-                    if (preg_match('/\b'.preg_quote($word, '/').'\b/i', $line) === 1 && ! isset($foundProfanity[$key])) {
-                        // Skip reporting profanity if the line contains the ignore annotation
-                        if (! str_contains($line, '@pest-ignore-profanity')) {
-                            $errors[] = new Error($file, $lineNumber + 1, $word);
-                            $foundProfanity[$key] = true;
-                        }
+            foreach ($lines as $lineNumber => $line) {
+                $key = $lineNumber.'-'.$word;
+                if (preg_match('/(?<!\p{L})'.preg_quote($word, '/').'(?!\p{L})/iu', $line) === 1 && !isset($foundProfanity[$key])) {
+                    // Skip reporting profanity if the line contains the ignore annotation
+                    if (!str_contains($line, '@pest-ignore-profanity')) {
+                        $errors[] = new Error($file, $lineNumber + 1, $word);
+                        $foundProfanity[$key] = true;
                     }
                 }
             }


### PR DESCRIPTION
Example in portuguese: 
'Colar de pérola' would get incorrectly flagged as profanity because it contains the last 4 chars that is a [bad word in pt_BR config](https://github.com/pestphp/pest-plugin-profanity/blob/06c77bb058ef577ff1e744ba853c08c015b31792/src/Config/profanities/pt_BR.php#L114).
After this fix:  PASS  No profanity found in your application!

```
\p{L} matches any Unicode letter.
(?<!\p{L}) ensures the character before isn’t a letter.
(?!\p{L}) ensures the character after isn’t a letter.
u flag = Unicode mode
i flag = case-insensitive
```