### PR TITLE
bump `pest-plugin-inside`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require-dev": {
-        "faissaloux/pest-plugin-inside": "^1.9",
+        "faissaloux/pest-plugin-inside": "^1.11",
         "pestphp/pest": "^5.0.0",
         "pestphp/pest-dev-tools": "^5.0.0"
     },


### PR DESCRIPTION
`faissaloux/pest-plugin-inside:v1.11` supports `pest:v5`.

https://github.com/faissaloux/pest-plugin-inside/releases/tag/v1.11.0